### PR TITLE
Update graph.py

### DIFF
--- a/gremlinrestclient/graph.py
+++ b/gremlinrestclient/graph.py
@@ -75,7 +75,7 @@ class Graph:
                 vertices[id(arg)] = self._process_vertex(arg, vertices, elements)
             elif isinstance(arg, tuple):
                 source, label, target = arg[:3]
-                properties = arg[4:4] or {}
+                properties = arg[3] or {}
                 source_vertex = self._process_vertex(source, vertices, elements)
                 target_vertex = self._process_vertex(target, vertices, elements)
                 alias = "e%s" % str(self._edge_alias)


### PR DESCRIPTION
edge properties failing with arg[4:4]
Example: e = (d, "LIKES", p, {'weight': 1})
arg must be '3'
